### PR TITLE
Add support for discard instructions

### DIFF
--- a/cilspirv.test.veldrid/Program.cs
+++ b/cilspirv.test.veldrid/Program.cs
@@ -5,6 +5,7 @@ using Veldrid.Sdl2;
 using Veldrid.StartupUtilities;
 using Veldrid.SPIRV;
 using System.Text;
+using System.Runtime.InteropServices;
 
 namespace cilspirv.test.veldrid
 {
@@ -14,28 +15,10 @@ namespace cilspirv.test.veldrid
         private static CommandList _commandList;
         private static DeviceBuffer _vertexBuffer;
         private static DeviceBuffer _indexBuffer;
+        private static DeviceBuffer identityBuffer, uniformBuffer;
+        private static ResourceSet resourceSet;
         private static Shader[] _shaders;
         private static Pipeline _pipeline;
-
-        private const string VertexCode = @"
-#version 450
-layout(location = 0) in vec2 Position;
-layout(location = 1) in vec4 Color;
-layout(location = 0) out vec4 fsin_Color;
-void main()
-{
-    gl_Position = vec4(Position, 0, 1);
-    fsin_Color = Color;
-}";
-
-        private const string FragmentCode = @"
-#version 450
-layout(location = 0) in vec4 fsin_Color;
-layout(location = 0) out vec4 fsout_Color;
-void main()
-{
-    fsout_Color = fsin_Color;
-}";
 
         static void Main(string[] args)
         {
@@ -76,15 +59,22 @@ void main()
         {
             ResourceFactory factory = _graphicsDevice.ResourceFactory;
 
-            VertexPositionColor[] quadVertices =
+            VertexPositionColor[] quadVerticesOld =
             {
                 new VertexPositionColor(new Vector2(-.75f, .75f), RgbaFloat.Red),
                 new VertexPositionColor(new Vector2(.75f, .75f), RgbaFloat.Green),
                 new VertexPositionColor(new Vector2(-.75f, -.75f), RgbaFloat.Blue),
                 new VertexPositionColor(new Vector2(.75f, -.75f), RgbaFloat.Yellow)
             };
+            SumVertex[] quadVertices =
+            {
+                new SumVertex(new Vector3(-.75f, .75f, 0), new(0f, 1f), RgbaFloat.Red),
+                new SumVertex(new Vector3(.75f, .75f, 0), new(1f, 1f), RgbaFloat.Green),
+                new SumVertex(new Vector3(-.75f, -.75f, 0), new(0f, 0f), RgbaFloat.Blue),
+                new SumVertex(new Vector3(.75f, -.75f, 0), new(1f, 0f), RgbaFloat.Yellow)
+            };
             BufferDescription vbDescription = new BufferDescription(
-                4 * VertexPositionColor.SizeInBytes,
+                4 * SumVertex.SizeInBytes,
                 BufferUsage.VertexBuffer);
             _vertexBuffer = factory.CreateBuffer(vbDescription);
             _graphicsDevice.UpdateBuffer(_vertexBuffer, 0, quadVertices);
@@ -97,16 +87,17 @@ void main()
             _graphicsDevice.UpdateBuffer(_indexBuffer, 0, quadIndices);
 
             VertexLayoutDescription vertexLayout = new VertexLayoutDescription(
-                new VertexElementDescription("Position", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float2),
+                new VertexElementDescription("Position", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float3),
+                new VertexElementDescription("UV", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float2),
                 new VertexElementDescription("Color", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float4));
 
             ShaderDescription vertexShaderDesc = new ShaderDescription(
                 ShaderStages.Vertex,
-                File.ReadAllBytes("Simple.spv"),
+                File.ReadAllBytes("Discard.spv"),
                 "Vert");
             ShaderDescription fragmentShaderDesc = new ShaderDescription(
                 ShaderStages.Fragment,
-                File.ReadAllBytes("Simple.spv"),
+                File.ReadAllBytes("Discard.spv"),
                 "Frag");
 
             //_shaders = factory.CreateFromSpirv(vertexShaderDesc, fragmentShaderDesc);
@@ -115,6 +106,30 @@ void main()
                 factory.CreateShader(vertexShaderDesc),
                 factory.CreateShader(fragmentShaderDesc)
             };
+
+            var uniforms = new test_shaders.Simple.Uniforms()
+            {
+                alphaReference = 0.3f,
+                tint = Vector4.One,
+                tintFactor = 0f,
+                vectorColorFactor = 1f
+            };
+            uniformBuffer = factory.CreateBuffer(new BufferDescription((uint)test_shaders.Simple.Uniforms.Size + 4, BufferUsage.UniformBuffer));
+            _graphicsDevice.UpdateBuffer(uniformBuffer, 0, ref uniforms);
+
+            identityBuffer = factory.CreateBuffer(new BufferDescription((uint)(4 * 4 * sizeof(float)), BufferUsage.UniformBuffer));
+            var identity = Matrix4x4.Identity;
+            _graphicsDevice.UpdateBuffer(identityBuffer, 0, ref identity);
+
+            var resourceLayout = factory.CreateResourceLayout(new ResourceLayoutDescription(
+                new ResourceLayoutElementDescription("B0", ResourceKind.UniformBuffer, ShaderStages.Vertex | ShaderStages.Fragment),
+                new ResourceLayoutElementDescription("B1", ResourceKind.UniformBuffer, ShaderStages.Vertex | ShaderStages.Fragment),
+                new ResourceLayoutElementDescription("projection", ResourceKind.UniformBuffer, ShaderStages.Vertex),
+                new ResourceLayoutElementDescription("view", ResourceKind.UniformBuffer, ShaderStages.Vertex),
+                new ResourceLayoutElementDescription("world", ResourceKind.UniformBuffer, ShaderStages.Vertex),
+                new ResourceLayoutElementDescription("uniforms", ResourceKind.UniformBuffer, ShaderStages.Fragment)));
+            resourceSet = factory.CreateResourceSet(new ResourceSetDescription(
+                resourceLayout, identityBuffer, identityBuffer, identityBuffer, identityBuffer, identityBuffer, uniformBuffer));
 
             // Create pipeline
             GraphicsPipelineDescription pipelineDescription = new GraphicsPipelineDescription();
@@ -154,6 +169,7 @@ void main()
             _commandList.SetVertexBuffer(0, _vertexBuffer);
             _commandList.SetIndexBuffer(_indexBuffer, IndexFormat.UInt16);
             _commandList.SetPipeline(_pipeline);
+            //_commandList.SetGraphicsResourceSet(0, resourceSet);
             // Issue a Draw command for a single instance with 4 indices.
             _commandList.DrawIndexed(
                 indexCount: 4,
@@ -192,6 +208,22 @@ void main()
         public VertexPositionColor(Vector2 position, RgbaFloat color)
         {
             Position = position;
+            Color = color;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = sizeof(float))]
+    struct SumVertex
+    {
+        public const uint SizeInBytes = (3 + 2 + 4) * sizeof(float);
+        public Vector3 Position;
+        public Vector2 UV;
+        public RgbaFloat Color;
+
+        public SumVertex(Vector3 position, Vector2 uv, RgbaFloat color)
+        {
+            Position = position;
+            UV = uv;
             Color = color;
         }
     }

--- a/cilspirv.test.veldrid/cilspirv.test.veldrid.csproj
+++ b/cilspirv.test.veldrid/cilspirv.test.veldrid.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Veldrid.StartupUtilities" Version="4.8.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\test-shaders\test-shaders.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/cilspirv.test.veldrid/packages.lock.json
+++ b/cilspirv.test.veldrid/packages.lock.json
@@ -1156,8 +1156,8 @@
       },
       "System.Numerics.Vectors": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
       },
       "System.ObjectModel": {
         "type": "Transitive",
@@ -1854,6 +1854,19 @@
         "contentHash": "sVfG2tYyu4k5vkAsn3FcqqW+EL3G0eyLDUsDmMUXuf2puNnhr3z1iA5H0DOzUiYfzRwAeEmPcZNp4pqv8uTvhg==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
+        }
+      },
+      "cilspirv": {
+        "type": "Project",
+        "dependencies": {
+          "System.Numerics.Vectors": "4.5.0"
+        }
+      },
+      "test-shaders": {
+        "type": "Project",
+        "dependencies": {
+          "System.Numerics.Vectors": "4.5.0",
+          "cilspirv": "1.0.0"
         }
       }
     }

--- a/cilspirv.transpiler.test/ControlFlowAnalysis/TestControlFlowAnalysis.UnreachableAtTheEnd.approved.txt
+++ b/cilspirv.transpiler.test/ControlFlowAnalysis/TestControlFlowAnalysis.UnreachableAtTheEnd.approved.txt
@@ -1,0 +1,4 @@
+﻿[0] 0
+  Edges: Out  In  Back
+  Dominators: Pre-0  Post-0
+    IL_0000: call System.Void cilspirv.Transpiler.test.TestControlFlowAnalysis::Unreachable()

--- a/cilspirv.transpiler.test/ControlFlowAnalysis/TestControlFlowAnalysis.UnreachableInConditionalAtEnd.approved.txt
+++ b/cilspirv.transpiler.test/ControlFlowAnalysis/TestControlFlowAnalysis.UnreachableInConditionalAtEnd.approved.txt
@@ -2,18 +2,17 @@
   Edges: Out-2-1  In  Back
   Dominators: Pre-0  Post-0
     IL_0000: ldarg.0
-    IL_0001: brfalse IL_000c
+    IL_0001: brtrue IL_000b
 
 [1] 0
   Edges: Out  In-0  Back
   Dominators: Pre-0  Post-1
-    IL_0006: newobj System.Void System.Exception::.ctor()
-    IL_000b: throw
+    IL_0006: call System.Void cilspirv.Transpiler.test.TestControlFlowAnalysis::Unreachable()
 
 [2] 0
   Edges: Out  In-0  Back
   Dominators: Pre-0  Post-2
-    IL_000c: ret
+    IL_000b: ret
 
 [3] MergeBlock, Unreachable Merge:<none>
   Edges: Out  In  Back

--- a/cilspirv.transpiler.test/ControlFlowAnalysis/TestControlFlowAnalysis.UnreachableInConditionalInMiddle.approved.txt
+++ b/cilspirv.transpiler.test/ControlFlowAnalysis/TestControlFlowAnalysis.UnreachableInConditionalInMiddle.approved.txt
@@ -1,0 +1,28 @@
+﻿[0] SelectionHeader Merge:4
+  Edges: Out-3-1  In  Back
+  Dominators: Pre-0  Post-0
+    IL_0000: ldarg.0
+    IL_0001: brtrue IL_000f
+
+[1] 0
+  Edges: Out  In-0  Back
+  Dominators: Pre-0  Post-1
+    IL_0006: call System.Void cilspirv.Transpiler.test.TestControlFlowAnalysis::Unreachable()
+
+[2] 0
+  Edges: Out-3  In  Back
+  Dominators: Pre-2  Post-3
+    IL_000b: ldarg.0
+    IL_000c: ldarg.0
+    IL_000d: sub
+    IL_000e: pop
+    IL_f00f: br IL_000f
+
+[3] 0
+  Edges: Out  In-0  Back
+  Dominators: Pre-0  Post-3
+    IL_000f: ret
+
+[4] MergeBlock, Unreachable Merge:<none>
+  Edges: Out  In  Back
+  Dominators: Pre-<none>  Post-<none>

--- a/cilspirv.transpiler.test/ControlFlowAnalysis/TestControlFlowAnalysis.UnreachableInTheMiddle.approved.txt
+++ b/cilspirv.transpiler.test/ControlFlowAnalysis/TestControlFlowAnalysis.UnreachableInTheMiddle.approved.txt
@@ -1,0 +1,12 @@
+﻿[0] 0
+  Edges: Out  In  Back
+  Dominators: Pre-0  Post-0
+    IL_0000: nop
+    IL_0001: nop
+    IL_0002: call System.Void cilspirv.Transpiler.test.TestControlFlowAnalysis::Unreachable()
+
+[1] 0
+  Edges: Out  In  Back
+  Dominators: Pre-1  Post-1
+    IL_0007: nop
+    IL_0008: ret

--- a/cilspirv.transpiler.test/cilspirv.transpiler.test.csproj
+++ b/cilspirv.transpiler.test/cilspirv.transpiler.test.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="5.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <Content Include="**/*.approved.txt" />
+    <PackageReference Include="ApprovalTests" Version="5.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/cilspirv.transpiler.test/packages.lock.json
+++ b/cilspirv.transpiler.test/packages.lock.json
@@ -4,12 +4,12 @@
     ".NETCoreApp,Version=v5.0": {
       "ApprovalTests": {
         "type": "Direct",
-        "requested": "[5.7.0, )",
-        "resolved": "5.7.0",
-        "contentHash": "wfdxTlxiXqGDiXELbW8nCzPJwRolgI5Npen7W8yXFNk4xTbr1tHmo+EXqzkIguUIdPfrOFWi1eBZvAQqFnkO8Q==",
+        "requested": "[5.7.1, )",
+        "resolved": "5.7.1",
+        "contentHash": "v8loRR3zbjeUZJcnJBDdb3ACVW3t+zkaQAEjdxMSxWKC3AgIryBmmAw6JxzIMpPnpQ7e17sXapXB3WftYztrdA==",
         "dependencies": {
-          "ApprovalUtilities": "5.7.0",
-          "DiffEngine": "7.0.0",
+          "ApprovalUtilities": "5.7.1",
+          "DiffEngine": "8.0.0",
           "EmptyFiles": "2.7.0",
           "Microsoft.Win32.Registry": "5.0.0",
           "TextCopy": "4.3.1"
@@ -23,12 +23,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[16.11.0, )",
-        "resolved": "16.11.0",
-        "contentHash": "f4mbG1SUSkNWF5p7B3Y8ZxMsvKhxCmpZhdl+w6tMtLSUGE7Izi1syU6TkmKOvB2BV66pdbENConFAISOix4ohQ==",
+        "requested": "[17.0.0, )",
+        "resolved": "17.0.0",
+        "contentHash": "fJcnMY3jX1MzJvhGvUWauRhU5eQsOaHdwlrcnI3NabBhbi8WLAkMFI8d0YnewA/+b9q/U7vbhp8Xmh1vJ05FYQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "16.11.0",
-          "Microsoft.TestPlatform.TestHost": "16.11.0"
+          "Microsoft.CodeCoverage": "17.0.0",
+          "Microsoft.TestPlatform.TestHost": "17.0.0"
         }
       },
       "NUnit": {
@@ -48,17 +48,17 @@
       },
       "ApprovalUtilities": {
         "type": "Transitive",
-        "resolved": "5.7.0",
-        "contentHash": "tfjvk30Km1aU7ItRwiiEIQazvjbqhuPyAFX1LvnuE8Cn7Ti+XUJ3cgLsaJlkFMLFlkhWG5YgG7Qm+yNNPySZgg==",
+        "resolved": "5.7.1",
+        "contentHash": "VVyrgVDWENFHmt2o6pt729Afj5YBbLjmh/wn77Bx29pLEq907d+2yEMXKjzU0yE7F7g9OewZ2UQfTLLfXqGkUw==",
         "dependencies": {
-          "System.Data.SqlClient": "4.8.2",
+          "System.Data.SqlClient": "4.8.3",
           "System.Management": "5.0.0"
         }
       },
       "DiffEngine": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "w0Wnbk7QaE+zDk8JxqUVhIUnF1qr6E1X9z0hX5qxQnpQ9hMQufVsR4iUPjUBE8Wa8caUGOwq5YMM0kWR09A15A==",
+        "resolved": "8.0.0",
+        "contentHash": "Cn4AoHZEC/qViqt+eKGvYwZj0T+QW4N4DswSra0cc6BUGOBAs/G4ocrJQl4hCp1fnDkIExOvg+GRWLehKrAnVg==",
         "dependencies": {
           "EmptyFiles": "2.7.0",
           "Microsoft.Windows.Compatibility": "5.0.2"
@@ -71,8 +71,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "16.11.0",
-        "contentHash": "wf6lpAeCqP0KFfbDVtfL50lr7jY1gq0+0oSphyksfLOEygMDXqnaxHK5LPFtMEhYSEtgXdNyXNnEddOqQQUdlQ=="
+        "resolved": "17.0.0",
+        "contentHash": "+B+09FPYBtf+cXfZOPIgpnP5mzLq5QdlBo+JEFy9CdqBaWHWE/YMY0Mos9uDsZhcgFegJm9GigAgMyqBZyfq+Q=="
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
@@ -114,8 +114,8 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "16.11.0",
-        "contentHash": "EiknJx9N9Z30gs7R+HHhki7fA8EiiM3pwD1vkw3bFsBC8kdVq/O7mHf1hrg5aJp+ASO6BoOzQueD2ysfTOy/Bg==",
+        "resolved": "17.0.0",
+        "contentHash": "WMugCdPkA8U/BsSRc+3RN+DXcaYSDvp/s0MofVld08iF1O5fek4iKecygk6NruNf1rgJsv4LK71mrwbyeqhzHA==",
         "dependencies": {
           "NuGet.Frameworks": "5.0.0",
           "System.Reflection.Metadata": "1.6.0"
@@ -123,10 +123,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "16.11.0",
-        "contentHash": "/Q+R0EcCJE8JaYCk+bGReicw/xrB0HhecrYrUcLbn95BnAlaTJrZhoLkUhvtKTAVtqX/AIKWXYtutiU/Q6QUgg==",
+        "resolved": "17.0.0",
+        "contentHash": "xkKFzm0hylHF0SlDj78ACYMJC/i8fQ3i16sDDNYoKnjTsstGSQfuSBJ+QT4nqRXk/fOiYTh+iY0KIX5N7HTLuQ==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "16.11.0",
+          "Microsoft.TestPlatform.ObjectModel": "17.0.0",
           "Newtonsoft.Json": "9.0.1"
         }
       },
@@ -374,8 +374,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.2",
-        "contentHash": "80vGtW6uLB4AkyrdVuKTXYUyuXDPAsSKbTVfvjndZaRAYxzFzWhJbvUfeAKrN+128ycWZjLIAl61dFUwWHOOTw==",
+        "resolved": "4.8.3",
+        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
         "dependencies": {
           "Microsoft.Win32.Registry": "4.7.0",
           "System.Security.Principal.Windows": "4.7.0",

--- a/cilspirv.transpiler/Transpiler/ControlFlowAnalysis.cs
+++ b/cilspirv.transpiler/Transpiler/ControlFlowAnalysis.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -67,6 +68,9 @@ namespace cilspirv.Transpiler
                     FlowControl.Throw => ExitKind.Exit,
                     _ => ExitKind.None
                 };
+                if (exitKind == ExitKind.None && ilInstr.OpCode == OpCodes.Call &&
+                    IsKillMethod((MethodReference)ilInstr.Operand))
+                    exitKind = ExitKind.Exit;
                 if (exitKind != ExitKind.None)
                     FinishBlock(i, exitKind);
             }
@@ -86,6 +90,14 @@ namespace cilspirv.Transpiler
             }
         }
 
+        internal static bool IsKillMethod(MethodReference methodRef) => methodRef
+            .Resolve()
+            .CustomAttributes
+            .Select(attr => attr.AttributeType)
+            .Any(typeRef =>
+                typeRef.Name == nameof(DoesNotReturnAttribute) || // only local name 
+                typeRef.FullName == typeof(Library.KillAttribute).FullName);
+
         /// <remarks>Also splits blocks where branches jump into</remarks>
         private void SetOutboundEdges()
         {
@@ -97,11 +109,8 @@ namespace cilspirv.Transpiler
                     edges.Add((block, targetInstr));
                 if (lastInstr.Operand is IEnumerable<Instruction> targetInstrs)
                     edges.AddRange(targetInstrs.Select(t => (block, t)));
-                if (lastInstr.OpCode.Code != Code.Ret &&
-                    lastInstr.OpCode.Code != Code.Throw &&
-                    lastInstr.OpCode.Code != Code.Rethrow &&
-                    lastInstr.OpCode.Code != Code.Br &&
-                    lastInstr.OpCode.Code != Code.Br_S)
+                if (block.ExitKind == ExitKind.CondBranch ||
+                    block.ExitKind == ExitKind.None)
                     edges.Add((block, lastInstr.Next));
             }
 

--- a/cilspirv.transpiler/Transpiler/GenInstructions.Branch.cs
+++ b/cilspirv.transpiler/Transpiler/GenInstructions.Branch.cs
@@ -99,7 +99,7 @@ namespace cilspirv.Transpiler
             private void Branch(ILInstruction me)
             {
                 var targetBlock = blocksByOffset[((ILInstruction)me.Operand).Offset];
-                targetBlock.Stack = Stack;
+                targetBlock.AddPreviousBlock(currentBlockInfo);
                 Add(new OpBranch()
                 {
                     TargetLabel = context.IDOf(targetBlock.block)
@@ -111,8 +111,8 @@ namespace cilspirv.Transpiler
                 var trueInstr = (ILInstruction)me.Operand;
                 var trueBlock = blocksByOffset[trueInstr.Offset];
                 var falseBlock = blocksByOffset[me.Next.Offset];
-                trueBlock.Stack = Stack;
-                falseBlock.Stack = Stack;
+                trueBlock.AddPreviousBlock(currentBlockInfo);
+                falseBlock.AddPreviousBlock(currentBlockInfo);
 
                 switch (CFABlock.HeaderBlockKind)
                 {

--- a/cilspirv.transpiler/Transpiler/GenInstructions.Variable.cs
+++ b/cilspirv.transpiler/Transpiler/GenInstructions.Variable.cs
@@ -170,7 +170,7 @@ namespace cilspirv.Transpiler
                 var parent = Pop();
                 var fieldBehavior = GetFieldBehavior(parent, fieldRef);
                 var context = new FieldContext(this, parent);
-                var instructions = fieldBehavior.LoadAddress(new FieldContext(this, parent))?.ToArray()
+                var instructions = fieldBehavior.LoadAddress(context)?.ToArray()
                     ?? throw new InvalidOperationException($"LoadAddress is not supported for field {fieldRef.FullName}");
 
                 Block.Instructions.AddRange(instructions);

--- a/cilspirv/Library/KillAttribute.cs
+++ b/cilspirv/Library/KillAttribute.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace cilspirv.Library
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class KillAttribute : Attribute { }
+}

--- a/test-shaders/Discard.cs
+++ b/test-shaders/Discard.cs
@@ -7,7 +7,7 @@ namespace test_shaders
 {
     [Capability(Capability.Shader)]
     [MemoryModel(AddressingModel.Logical, MemoryModel.GLSL450)]
-    public class Simple
+    public class Discard
     {
         public struct VSInput
         {
@@ -22,31 +22,15 @@ namespace test_shaders
             [Location(1)] public Vector4 color;
         }
 
-        public struct Uniforms
-        {
-            public const int Size = (4 + 1 + 1 + 1) * sizeof(float);
-
-            public Vector4 tint;
-            public float vectorColorFactor;
-            public float tintFactor;
-            public float alphaReference;
-        }
-
-        private Vector4 WeighColor(Vector4 color, float factor) =>
-            color * factor + new Vector4(1 - factor);
-
         [EntryPoint(ExecutionModel.Fragment)]
         public void Frag(
             [Input] in FSInput input,
-            
-            [Uniform, Binding(0, 5)] in Uniforms uniforms,
 
             [Output, Location(0)] out Vector4 output)
         {
-            output = input.color
-                * WeighColor(input.color, uniforms.vectorColorFactor)
-                * WeighColor(uniforms.tint, uniforms.tintFactor);
-            if (output.W < uniforms.alphaReference)
+            output = input.color;
+            int checker = (int)(input.uv.X * 8f) + (int)(input.uv.Y * 8);
+            if ((checker % 2) == 0)
                 Environment.Exit(0);
         }
 
@@ -54,17 +38,10 @@ namespace test_shaders
         public void Vert(
             [Input] in VSInput input,
 
-            [Uniform, Binding(0, 2)] in Matrix4x4 projection,
-            [Uniform, Binding(0, 3)] in Matrix4x4 view,
-            [Uniform, Binding(0, 4)] in Matrix4x4 world,
-
             [Output, BuiltIn(BuiltIn.Position)] out Vector4 position,
             [Output] out FSInput output)
         {
             position = new Vector4(input.pos, 1f);
-            position = Vector4.Transform(position, world);
-            position = Vector4.Transform(position, view);
-            position = Vector4.Transform(position, projection);
             output.uv = input.uv;
             output.color = input.color;
         }

--- a/test-shaders/Simple.cs
+++ b/test-shaders/Simple.cs
@@ -45,7 +45,7 @@ namespace test_shaders
                 * WeighColor(input.color, uniforms.vectorColorFactor)
                 * WeighColor(uniforms.tint, uniforms.tintFactor);
             if (output.W < uniforms.alphaReference)
-                throw new DiscardException();
+                Environment.Exit(0);
         }
 
         [EntryPoint(ExecutionModel.Vertex)]


### PR DESCRIPTION
By treating methods with a  `System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute` or a `cilspirv.Library.KillAttribute` as discard instructions. These methods should ideally not return any value or have parameters. 
At least do not invoke sideeffects in the parameters please.